### PR TITLE
Add release notes to promoteRelease

### DIFF
--- a/pacts/npm_consumer-vp_service.json
+++ b/pacts/npm_consumer-vp_service.json
@@ -113,6 +113,16 @@
       "description": "a request for promoting a release",
       "providerState": "release promoted",
       "request": {
+        "body": {
+          "channelIds": [
+            "channelid"
+          ],
+          "releaseNotesGzip": "H4sIAAAAAAAAA1MqSs1JTSxOVcjLL0ktVgIAxFWEEQ8AAAA=",
+          "versionLabel": "v1.0.0"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
         "method": "POST",
         "path": "/app/1234abcd/release/1/promote"
       },

--- a/src/releases.spec.ts
+++ b/src/releases.spec.ts
@@ -3,7 +3,7 @@ import { ReleaseChart, exportedForTesting, KotsSingleSpec, createReleaseFromChar
 import * as mockttp from "mockttp";
 import * as fs from "fs-extra";
 import * as path from "path";
-import { sl } from "date-fns/locale";
+import { gzip } from "pako";
 
 const areReleaseChartsPushed = exportedForTesting.areReleaseChartsPushed;
 const getReleaseByAppId = exportedForTesting.getReleaseByAppId;
@@ -23,7 +23,12 @@ describe("Promote Release", () => {
       uponReceiving: "a request for promoting a release",
       withRequest: {
         method: "POST",
-        path: "/app/1234abcd/release/1/promote"
+        path: "/app/1234abcd/release/1/promote",
+        body: {
+          versionLabel: "v1.0.0",
+          channelIds: ["channelid"],
+          releaseNotesGzip: Buffer.from(gzip(JSON.stringify("release notes"))).toString("base64")
+        }
       },
       willRespondWith: {
         status: 200,
@@ -35,7 +40,7 @@ describe("Promote Release", () => {
     apiClient.apiToken = "abcd1234";
     apiClient.endpoint = globalThis.provider.mockService.baseUrl;
 
-    return promoteReleaseByAppId(apiClient, "1234abcd", "channelid", 1, "v1.0.0")
+    return promoteReleaseByAppId(apiClient, "1234abcd", "channelid", 1, "v1.0.0", "release notes")
       .then(() => {
         expect(true).toEqual(true);
       })

--- a/src/releases.ts
+++ b/src/releases.ts
@@ -213,20 +213,23 @@ function isSupportedExt(ext: string): boolean {
   return supportedExts.includes(ext);
 }
 
-export async function promoteRelease(vendorPortalApi: VendorPortalApi, appSlug: string, channelId: string, releaseSequence: number, version: string) {
+export async function promoteRelease(vendorPortalApi: VendorPortalApi, appSlug: string, channelId: string, releaseSequence: number, version: string, releaseNotes?: string) {
   // 1. get the app id from the app slug
   const app = await getApplicationDetails(vendorPortalApi, appSlug);
 
   // 2. promote the release
-  await promoteReleaseByAppId(vendorPortalApi, app.id, channelId, releaseSequence, version);
+  await promoteReleaseByAppId(vendorPortalApi, app.id, channelId, releaseSequence, version, releaseNotes);
 }
 
-async function promoteReleaseByAppId(vendorPortalApi: VendorPortalApi, appId: string, channelId: string, releaseSequence: number, version: string) {
+async function promoteReleaseByAppId(vendorPortalApi: VendorPortalApi, appId: string, channelId: string, releaseSequence: number, version: string, releaseNotes?: string) {
   const http = await vendorPortalApi.client();
   const reqBody = {
     versionLabel: version,
     channelIds: [channelId]
   };
+  if (releaseNotes) {
+    reqBody["releaseNotesGzip"] = gzipData(releaseNotes);
+  }
   const uri = `${vendorPortalApi.endpoint}/app/${appId}/release/${releaseSequence}/promote`;
   const res = await http.post(uri, JSON.stringify(reqBody));
   if (res.message.statusCode != 200) {


### PR DESCRIPTION
Add support for specifying release notes when promoting a release.

https://app.shortcut.com/replicated/story/111264/release-notes-argument-for-create-release-action